### PR TITLE
build(deps): BREAKING CHANGE: update `derive_more` 0.15 -> 0.99 for rumq-{client,core}

### DIFF
--- a/rumq-client/Cargo.toml
+++ b/rumq-client/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-derive_more = "0.15"
+derive_more = "0.99"
 tokio = { version = "0.2", features = ["io-util", "tcp", "dns", "sync", "time"] }
 async-stream = "0.2"
 futures-util = "0.3"

--- a/rumq-core/Cargo.toml
+++ b/rumq-core/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["tekjar"]
 edition = "2018"
 
 [dependencies]
-derive_more = "0.15"
+derive_more = "0.99"
 tokio = { version = "0.2", features = ["io-util"] }
 async-trait = "0.1"
 getset = "0.0.9"

--- a/rumq-core/src/lib.rs
+++ b/rumq-core/src/lib.rs
@@ -110,6 +110,7 @@ pub fn connect_return(num: u8) -> Result<ConnectReturnCode, Error> {
 
 #[derive(Debug, From)]
 pub enum Error {
+    #[from(ignore)]
     InvalidConnectReturnCode(u8),
     InvalidProtocolName(String),
     InvalidProtocolLevel(String, u8),
@@ -118,6 +119,7 @@ pub enum Error {
     UnsupportedProtocolName,
     UnsupportedProtocolVersion,
     UnsupportedQoS,
+    #[from(ignore)]
     UnsupportedPacketType(u8),
     UnsupportedConnectReturnCode,
     PayloadSizeIncorrect,


### PR DESCRIPTION
This is a breaking change because `From` implementations (in particular, those implemented by `derive_more::From` on `rumq_client::Error`) are public API surface -- this could be kept as an implementation detail in the future by using an error newtype.