### PR TITLE
Reset self.await_pingresp if we miss ping response

### DIFF
--- a/rumq-client/src/state.rs
+++ b/rumq-client/src/state.rs
@@ -273,6 +273,7 @@ impl MqttState {
         // raise error if last ping didn't receive ack
         if self.await_pingresp {
             error!("Error awaiting for last ping response");
+            self.await_pingresp = false;
             return Err(StateError::AwaitPingResp);
         }
 


### PR DESCRIPTION
We missed the ping. It's over. It's never coming back.
The only thing we can do is send a new request, and wait for the response to that one.

tentatively fixes #34