### PR TITLE
Bump env-logger dependencies

### DIFF
--- a/rumq-cli/Cargo.toml
+++ b/rumq-cli/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 tokio = { version = "0.2", features = ["full"] }
 structopt = "0.3"
-pretty_env_logger = "0.3"
+pretty_env_logger = "0.4"
 toml = "0.5"
 rumq-broker = { path = "../rumq-broker", version = "0.1.0-alpha.5" }
 serde = { version = "1", features = ["derive"] }

--- a/rumq-client/Cargo.toml
+++ b/rumq-client/Cargo.toml
@@ -21,8 +21,8 @@ rumq-core = { path = "../rumq-core", version = "0.1.0-alpha.7" }
 log = "0.4"
 
 [dev-dependencies]
-pretty_env_logger = "0.3.1"
-color-backtrace = "0.2.3"
+pretty_env_logger = "0.4"
+color-backtrace = "0.3"
 crossbeam-channel = "0.4"
 serde = {version = "1", features = ["derive"]}
 envy = "0.4"


### PR DESCRIPTION
This reduces the number of indirect dependencies by quite a bit

Signed-off-by: Daniel Egger <daniel@eggers-club.de>