### PR TITLE
Last will + some changes to names

### DIFF
--- a/rumq-client/examples/gcloud.rs
+++ b/rumq-client/examples/gcloud.rs
@@ -3,7 +3,7 @@ use std::ops::Add;
 use std::env;
 use std::fs;
 
-use rumq_client::{self, QoS, MqttOptions, Request, MqttEventLoop, eventloop};
+use rumq_client::{self, QoS, MqttOptions, Request, MqttEventLoop, create_eventloop};
 use serde::{Serialize, Deserialize};
 use jsonwebtoken::{encode, Algorithm, Header, EncodingKey};
 use futures_util::stream::StreamExt;
@@ -20,7 +20,7 @@ async fn main() {
 
     let (requests_tx, requests_rx) = channel(1);
     let mqttoptions = gcloud();
-    let mut eventloop = eventloop(mqttoptions, requests_rx);
+    let mut eventloop = create_eventloop(mqttoptions, requests_rx);
 
     task::spawn(async move {
         requests(requests_tx).await;
@@ -43,10 +43,10 @@ async fn stream_it(eventloop: &mut MqttEventLoop) {
 async fn requests(mut requests_tx: Sender<Request>) {
     for i in 0..15 {
         requests_tx.send(publish_request(i)).await.unwrap();
-        time::delay_for(Duration::from_secs(1)).await; 
+        time::delay_for(Duration::from_secs(1)).await;
     }
 
-    time::delay_for(Duration::from_secs(100)).await; 
+    time::delay_for(Duration::from_secs(100)).await;
 }
 
 fn gcloud() -> MqttOptions {
@@ -59,7 +59,7 @@ fn gcloud() -> MqttOptions {
         .set_ca(ca)
         .set_credentials("unused", &password);
 
-    mqttoptions 
+    mqttoptions
 }
 
 fn publish_request(i: u8) -> Request {

--- a/rumq-client/examples/pubsub.rs
+++ b/rumq-client/examples/pubsub.rs
@@ -2,7 +2,7 @@ use tokio::sync::mpsc::{channel, Sender};
 use tokio::{time, task};
 use tokio::stream::StreamExt;
 
-use rumq_client::{self, MqttOptions, QoS, Request, MqttEventLoop, eventloop};
+use rumq_client::{self, MqttOptions, QoS, Request, MqttEventLoop, create_eventloop};
 use std::time::Duration;
 
 #[tokio::main(basic_scheduler)]
@@ -14,7 +14,7 @@ async fn main() {
     let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
 
     mqttoptions.set_keep_alive(5).set_throttle(Duration::from_secs(1));
-    let mut eventloop = eventloop(mqttoptions, requests_rx);
+    let mut eventloop = create_eventloop(mqttoptions, requests_rx);
     task::spawn(async move {
         requests(requests_tx).await;
         time::delay_for(Duration::from_secs(3)).await;
@@ -43,10 +43,10 @@ async fn requests(mut requests_tx: Sender<Request>) {
 
     for i in 0..10 {
         requests_tx.send(publish_request(i)).await.unwrap();
-        time::delay_for(Duration::from_secs(1)).await; 
+        time::delay_for(Duration::from_secs(1)).await;
     }
 
-    time::delay_for(Duration::from_secs(60)).await; 
+    time::delay_for(Duration::from_secs(60)).await;
 }
 
 fn publish_request(i: u8) -> Request {

--- a/rumq-client/examples/reconnection.rs
+++ b/rumq-client/examples/reconnection.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc::{channel, Sender};
 use tokio::task;
 use tokio::time;
 
-use rumq_client::{self, QoS, MqttOptions, Request, MqttEventLoop, eventloop};
+use rumq_client::{self, QoS, MqttOptions, Request, MqttEventLoop, create_eventloop};
 use std::time::Duration;
 
 #[tokio::main(basic_scheduler)]
@@ -15,7 +15,7 @@ async fn main() {
     mqttoptions.set_keep_alive(5).set_throttle(Duration::from_secs(1));
 
     let (requests_tx, requests_rx) = channel(10);
-    let mut eventloop = eventloop(mqttoptions, requests_rx);
+    let mut eventloop = create_eventloop(mqttoptions, requests_rx);
 
     // start sending requests
     task::spawn(async move {
@@ -50,6 +50,6 @@ async fn requests(mut requests_tx: Sender<Request>) {
         let publish = Request::Publish(publish);
 
         requests_tx.send(publish).await.unwrap();
-        time::delay_for(Duration::from_secs(1)).await; 
+        time::delay_for(Duration::from_secs(1)).await;
     }
 }

--- a/rumq-client/examples/smoke.rs
+++ b/rumq-client/examples/smoke.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc::{channel, Sender};
 use tokio::task;
 use tokio::time;
 
-use rumq_client::{self, QoS, MqttOptions, Request, MqttEventLoop, eventloop};
+use rumq_client::{self, QoS, MqttOptions, Request, MqttEventLoop, create_eventloop};
 use std::time::Duration;
 
 #[tokio::main(basic_scheduler)]
@@ -14,7 +14,7 @@ async fn main() {
     let (requests_tx, requests_rx) = channel(10);
     let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
     mqttoptions.set_keep_alive(30).set_throttle(Duration::from_secs(1));
-    let mut eventloop = eventloop(mqttoptions, requests_rx);
+    let mut eventloop = create_eventloop(mqttoptions, requests_rx);
 
     task::spawn(async move {
         requests(requests_tx).await;
@@ -37,10 +37,10 @@ async fn stream_it(eventloop: &mut MqttEventLoop) {
 async fn requests(mut requests_tx: Sender<Request>) {
     for i in 0..10 {
         requests_tx.send(publish_request(i)).await.unwrap();
-        time::delay_for(Duration::from_secs(1)).await; 
+        time::delay_for(Duration::from_secs(1)).await;
     }
 
-    time::delay_for(Duration::from_secs(600)).await; 
+    time::delay_for(Duration::from_secs(600)).await;
 }
 
 fn publish_request(i: u8) -> Request {

--- a/rumq-client/examples/tls.rs
+++ b/rumq-client/examples/tls.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc::{channel, Sender};
 use tokio::task;
 use tokio::time;
 
-use rumq_client::{self, MqttOptions, QoS, Request, MqttEventLoop, eventloop};
+use rumq_client::{self, MqttOptions, QoS, Request, MqttEventLoop, create_eventloop};
 use std::time::Duration;
 use std::fs;
 
@@ -11,18 +11,18 @@ use std::fs;
 async fn main() {
     pretty_env_logger::init();
     color_backtrace::install();
-    
+
     let ca = fs::read("certs/tlsfiles/ca-chain.cert.pem").unwrap();
     let client_cert = fs::read("certs/tlsfiles/device-1.cert.pem").unwrap();
     let client_key = fs::read("certs/tlsfiles/device-1.key.pem").unwrap();
-    
+
     let (requests_tx, requests_rx) = channel(10);
     let mut mqttoptions = MqttOptions::new("device-1", "mqtt.bytebeam.io", 8883);
     mqttoptions.set_keep_alive(5).set_throttle(Duration::from_secs(1));
     mqttoptions.set_ca(ca);
     // mqttoptions.set_client_auth(client_cert, client_key);
-    
-    let mut eventloop = eventloop(mqttoptions, requests_rx);
+
+    let mut eventloop = create_eventloop(mqttoptions, requests_rx);
     task::spawn(async move {
         requests(requests_tx).await;
         time::delay_for(Duration::from_secs(3)).await;
@@ -51,10 +51,10 @@ async fn requests(mut requests_tx: Sender<Request>) {
 
     for i in 0..10 {
         requests_tx.send(publish_request(i)).await.unwrap();
-        time::delay_for(Duration::from_secs(1)).await; 
+        time::delay_for(Duration::from_secs(1)).await;
     }
 
-    time::delay_for(Duration::from_secs(60)).await; 
+    time::delay_for(Duration::from_secs(60)).await;
 }
 
 fn publish_request(i: u8) -> Request {

--- a/rumq-client/src/eventloop.rs
+++ b/rumq-client/src/eventloop.rs
@@ -33,7 +33,7 @@ pub struct MqttEventLoop {
 }
 
 
-/// Critical errors during eventloop polling 
+/// Critical errors during eventloop polling
 #[derive(From, Debug)]
 pub enum EventLoopError {
     MqttState(StateError),
@@ -44,14 +44,19 @@ pub enum EventLoopError {
     StreamDone
 }
 
+/// See [eventloop](eventloop)
+pub fn create_eventloop(options: MqttOptions, requests: impl Requests + 'static) -> MqttEventLoop {
+    eventloop(options, requests)
+}
+
 /// Returns an object which encompasses state of the connection.
 /// Use this to create a `Stream` with `stream()` method and poll it with tokio.
 ///
 /// The choice of separating `MqttEventLoop` and `stream` methods is to get access to the
-/// internal state and mqtt options after the work with the `Stream` is done or stopped. 
+/// internal state and mqtt options after the work with the `Stream` is done or stopped.
 /// This is useful in scenarios like shutdown where the current state should be persisted or
 /// during reconnection when the state from last disconnection should be resumed.
-/// For a similar reason, requests are also initialized as part of this method to reuse same 
+/// For a similar reason, requests are also initialized as part of this method to reuse same
 /// request stream while retrying after the previous `Stream` has stopped
 /// ```ignore
 /// let mut eventloop = eventloop(options, requests);
@@ -60,10 +65,11 @@ pub enum EventLoopError {
 ///     while let Some(notification) = stream.next().await() {}
 /// }
 /// ```
-/// When mqtt `stream` ends due to critical errors (like auth failure), user has a choice to 
+/// When mqtt `stream` ends due to critical errors (like auth failure), user has a choice to
 /// access and update `options`, `state` and `requests`.
 /// For example, state and requests can be used to save state to disk before shutdown.
 /// Options can be used to update gcp iotcore password
+#[deprecated(since="0.1.0-alpha-8", note="use create_eventloop instead")]
 pub fn eventloop(options: MqttOptions, requests: impl Requests + 'static) -> MqttEventLoop {
     let state = MqttState::new();
     let requests = Box::new(requests);
@@ -100,7 +106,7 @@ impl MqttEventLoop {
             let mut network_stream = network_stream(self.options.keep_alive, network_rx);
             let mut request_stream = request_stream(self.options.keep_alive, self.options.throttle, &mut pending, &mut self.requests);
 
-            pin!(network_stream, request_stream); 
+            pin!(network_stream, request_stream);
 
             // FIXME stream! doesn't allow yield in select! yet and using a variable to store exit
             // status of every branch is resulting in ICE crash
@@ -112,7 +118,7 @@ impl MqttEventLoop {
                         Some(o) => self.state.handle_packet(o),
                         None => {
                             exit = Some(Notification::NetworkClosed);
-                            break 
+                            break
                         }
                     }
                 } else {
@@ -128,7 +134,7 @@ impl MqttEventLoop {
                             Some(o) => self.state.handle_request(o),
                             None => {
                                 exit = Some(Notification::RequestsDone);
-                                break 
+                                break
                             }
                         }
                     }
@@ -152,7 +158,7 @@ impl MqttEventLoop {
                     // network_tx.flush().await?;
                 }
 
-                // yield the notification to the user 
+                // yield the notification to the user
                 if let Some(n) = notification { yield n }
             }
 
@@ -164,7 +170,7 @@ impl MqttEventLoop {
 
         Box::pin(stream)
     }
-    
+
     fn populate_pending(&mut self) {
         let mut pending_pub = mem::replace(&mut self.state.outgoing_pub, VecDeque::new());
         self.pending_pub.append(&mut pending_pub);
@@ -180,7 +186,7 @@ impl MqttEventLoop {
 /// The caveat with generating pingreq on requsts rather than considering outgoing packets
 /// including replys due to incoming packets is that we generate unnecessary pingreqs when there
 /// are no user requests but there is outgoing network activity due to incoming packets like qos1
-/// publish. 
+/// publish.
 /// See desgin notes for understanding this design choice
 fn request_stream<R: Requests, P: Packets>(keep_alive: Duration, throttle: Duration, pending: P, requests: R) -> impl Stream<Item = Packet> {
     stream! {
@@ -201,7 +207,7 @@ fn request_stream<R: Requests, P: Packets>(keep_alive: Duration, throttle: Durat
                 }
             }
         }
-        
+
         let mut requests = time::throttle(throttle, requests);
         loop {
             let timeout_request = time::timeout(keep_alive, async {
@@ -225,9 +231,9 @@ fn request_stream<R: Requests, P: Packets>(keep_alive: Duration, throttle: Durat
 /// Network stream. Generates pingreq when there is no incoming packet for keepalive + 1 time to
 /// find halfopen connections to the broker. keep alive + 1 is necessary so that when the
 /// connection is idle on both incoming and outgoing packets, we trigger pingreq on both requests
-/// and incoming which trigger await_pingresp error. 
-/// 
-/// Maintaing a gap between both allows network stream to receive pingresp and hence not timeout 
+/// and incoming which trigger await_pingresp error.
+///
+/// Maintaing a gap between both allows network stream to receive pingresp and hence not timeout
 /// due to incoming activity because of request ping. pingreq should be received with in one second
 /// or else pingreq due to network timeout will cause await_pingresp erorr. This is ok as
 /// pingpacket round trip size = 4 bytes. If network bandwidth is worse than 4 bytes per second,
@@ -260,7 +266,7 @@ fn network_stream<S: NetworkRead>(keep_alive: Duration, mut network: S) -> impl 
 
             match packet {
                 Ok(packet) => yield packet,
-                Err(_) => break 
+                Err(_) => break
             }
         }
     }
@@ -376,15 +382,15 @@ mod test {
 
         time::delay_for(Duration::from_secs(1)).await;
         let options = MqttOptions::new("dummy", "127.0.0.1", 1880);
-        let mut eventloop = super::eventloop(options, requests_rx); 
+        let mut eventloop = super::eventloop(options, requests_rx);
 
-        let start = Instant::now(); 
+        let start = Instant::now();
         let o = eventloop.connect().await;
         let elapsed = start.elapsed();
 
         match o {
             Ok(_) => assert!(false),
-            Err(super::EventLoopError::Timeout(_)) => assert!(true), 
+            Err(super::EventLoopError::Timeout(_)) => assert!(true),
             Err(_) => assert!(false)
         }
 
@@ -407,7 +413,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx); 
+            let mut eventloop = super::eventloop(options, requests_rx);
             let mut stream = eventloop.stream();
 
             while let Some(_) = stream.next().await {}
@@ -420,10 +426,10 @@ mod test {
         // check incoming rate at th broker
         for i in 0..10 {
             let start = Instant::now();
-            let _ = stream.next().await.unwrap(); 
+            let _ = stream.next().await.unwrap();
             let elapsed = start.elapsed();
 
-            if i > 0 { 
+            if i > 0 {
                 dbg!(elapsed.as_millis());
                 assert_eq!(elapsed.as_secs(), options2.throttle.as_secs())
             }
@@ -442,7 +448,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx); 
+            let mut eventloop = super::eventloop(options, requests_rx);
             let mut stream = eventloop.stream();
 
             while let Some(_) = stream.next().await {}
@@ -454,7 +460,7 @@ mod test {
 
         // check incoming rate at th broker
         let start = Instant::now();
-        let packet = stream.next().await.unwrap(); 
+        let packet = stream.next().await.unwrap();
         let elapsed = start.elapsed();
 
         assert_eq!(packet, Packet::Pingreq);
@@ -482,7 +488,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx); 
+            let mut eventloop = super::eventloop(options, requests_rx);
             let mut stream = eventloop.stream();
 
             while let Some(_) = stream.next().await {}
@@ -496,9 +502,9 @@ mod test {
         let mut ping_received = false;
 
         for _i in 0..10 {
-            let packet = stream.next().await.unwrap(); 
+            let packet = stream.next().await.unwrap();
             let elapsed = start.elapsed();
-            if packet == Packet::Pingreq { 
+            if packet == Packet::Pingreq {
                 ping_received = true;
                 assert_eq!(elapsed.as_secs(), keep_alive.as_secs() + 1); // add 1 due to keep alive network implementation
                 break
@@ -529,7 +535,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx); 
+            let mut eventloop = super::eventloop(options, requests_rx);
             let mut stream = eventloop.stream();
 
             while let Some(_) = stream.next().await {}
@@ -538,9 +544,9 @@ mod test {
 
         let mut broker = broker(1887, true).await;
         for i in 1..=10 {
-            let packet = broker.async_mqtt_read().await; 
+            let packet = broker.async_mqtt_read().await;
 
-            if i > inflight { 
+            if i > inflight {
                 assert!(packet.is_none());
             }
         }
@@ -568,7 +574,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx); 
+            let mut eventloop = super::eventloop(options, requests_rx);
             let mut stream = eventloop.stream();
             while let Some(_p) = stream.next().await {}
         });
@@ -576,27 +582,27 @@ mod test {
         let mut broker = broker(1888, true).await;
 
         // packet 1
-        let packet = broker.async_mqtt_read().await; 
+        let packet = broker.async_mqtt_read().await;
         assert!(packet.is_some());
         // packet 2
-        let packet = broker.async_mqtt_read().await; 
+        let packet = broker.async_mqtt_read().await;
         assert!(packet.is_some());
         // packet 3
-        let packet = broker.async_mqtt_read().await; 
+        let packet = broker.async_mqtt_read().await;
         assert!(packet.is_some());
-        // packet 4 
-        let packet = broker.async_mqtt_read().await; 
+        // packet 4
+        let packet = broker.async_mqtt_read().await;
         assert!(packet.is_none());
         // ack packet 1 and we should receiver packet 4
         broker.ack(PacketIdentifier(1)).await;
-        let packet = broker.async_mqtt_read().await; 
+        let packet = broker.async_mqtt_read().await;
         assert!(packet.is_some());
-        // packet 5 
-        let packet = broker.async_mqtt_read().await; 
+        // packet 5
+        let packet = broker.async_mqtt_read().await;
         assert!(packet.is_none());
         // ack packet 2 and we should receiver packet 5
         broker.ack(PacketIdentifier(2)).await;
-        let packet = broker.async_mqtt_read().await; 
+        let packet = broker.async_mqtt_read().await;
         assert!(packet.is_some());
     }
 
@@ -621,7 +627,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx); 
+            let mut eventloop = super::eventloop(options, requests_rx);
 
             loop {
                 let mut stream = eventloop.stream();
@@ -633,7 +639,7 @@ mod test {
         {
             let mut broker = broker(1889, true).await;
             for i in 1..=2 {
-                let packet = broker.async_mqtt_read().await; 
+                let packet = broker.async_mqtt_read().await;
                 assert_eq!(PacketIdentifier(i), packet.unwrap());
                 broker.ack(packet.unwrap()).await;
             }
@@ -643,7 +649,7 @@ mod test {
         {
             let mut broker = broker(1889, true).await;
             for i in 3..=4 {
-                let packet = broker.async_mqtt_read().await; 
+                let packet = broker.async_mqtt_read().await;
                 assert_eq!(PacketIdentifier(i), packet.unwrap());
                 broker.ack(packet.unwrap()).await;
             }
@@ -671,7 +677,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx); 
+            let mut eventloop = super::eventloop(options, requests_rx);
 
             loop {
                 let mut stream = eventloop.stream();
@@ -683,7 +689,7 @@ mod test {
         {
             let mut broker = broker(1890, true).await;
             for i in 1..=2 {
-                let packet = broker.async_mqtt_read().await; 
+                let packet = broker.async_mqtt_read().await;
                 assert_eq!(PacketIdentifier(i), packet.unwrap());
             }
         }
@@ -692,7 +698,7 @@ mod test {
         {
             let mut broker = broker(1890, true).await;
             for i in 1..=6 {
-                let packet = broker.async_mqtt_read().await; 
+                let packet = broker.async_mqtt_read().await;
                 assert_eq!(PacketIdentifier(i), packet.unwrap());
             }
         }
@@ -750,7 +756,7 @@ mod test {
         }
 
         async fn ack(&mut self, pkid: PacketIdentifier) {
-            let packet = Packet::Puback(pkid); 
+            let packet = Packet::Puback(pkid);
             self.stream.async_mqtt_write(&packet).await.unwrap();
             self.stream.flush().await.unwrap();
         }

--- a/rumq-client/src/eventloop.rs
+++ b/rumq-client/src/eventloop.rs
@@ -44,10 +44,11 @@ pub enum EventLoopError {
     StreamDone
 }
 
-/// See [eventloop](eventloop)
-pub fn create_eventloop(options: MqttOptions, requests: impl Requests + 'static) -> MqttEventLoop {
-    #[allow(deprecated)]
-    eventloop(options, requests)
+#[doc(hidden)]
+#[deprecated(since="0.1.0-alpha-8", note="use create_eventloop instead")]
+/// See [create_eventloop](create_eventloop)
+pub fn eventloop(options: MqttOptions, requests: impl Requests + 'static) -> MqttEventLoop {
+    create_eventloop(options, requests)
 }
 
 /// Returns an object which encompasses state of the connection.
@@ -60,7 +61,7 @@ pub fn create_eventloop(options: MqttOptions, requests: impl Requests + 'static)
 /// For a similar reason, requests are also initialized as part of this method to reuse same
 /// request stream while retrying after the previous `Stream` has stopped
 /// ```ignore
-/// let mut eventloop = eventloop(options, requests);
+/// let mut eventloop = create_eventloop(options, requests);
 /// loop {
 ///     let mut stream = eventloop.stream(reconnection_options);
 ///     while let Some(notification) = stream.next().await() {}
@@ -70,8 +71,7 @@ pub fn create_eventloop(options: MqttOptions, requests: impl Requests + 'static)
 /// access and update `options`, `state` and `requests`.
 /// For example, state and requests can be used to save state to disk before shutdown.
 /// Options can be used to update gcp iotcore password
-#[deprecated(since="0.1.0-alpha-8", note="use create_eventloop instead")]
-pub fn eventloop(options: MqttOptions, requests: impl Requests + 'static) -> MqttEventLoop {
+pub fn create_eventloop(options: MqttOptions, requests: impl Requests + 'static) -> MqttEventLoop {
     let state = MqttState::new();
     let requests = Box::new(requests);
     let pending_pub = VecDeque::new();
@@ -385,7 +385,7 @@ mod test {
 
         time::delay_for(Duration::from_secs(1)).await;
         let options = MqttOptions::new("dummy", "127.0.0.1", 1880);
-        let mut eventloop = super::eventloop(options, requests_rx);
+        let mut eventloop = super::create_eventloop(options, requests_rx);
 
         let start = Instant::now();
         let o = eventloop.connect().await;
@@ -416,7 +416,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx);
+            let mut eventloop = super::create_eventloop(options, requests_rx);
             let mut stream = eventloop.stream();
 
             while let Some(_) = stream.next().await {}
@@ -451,7 +451,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx);
+            let mut eventloop = super::create_eventloop(options, requests_rx);
             let mut stream = eventloop.stream();
 
             while let Some(_) = stream.next().await {}
@@ -491,7 +491,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx);
+            let mut eventloop = super::create_eventloop(options, requests_rx);
             let mut stream = eventloop.stream();
 
             while let Some(_) = stream.next().await {}
@@ -538,7 +538,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx);
+            let mut eventloop = super::create_eventloop(options, requests_rx);
             let mut stream = eventloop.stream();
 
             while let Some(_) = stream.next().await {}
@@ -577,7 +577,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx);
+            let mut eventloop = super::create_eventloop(options, requests_rx);
             let mut stream = eventloop.stream();
             while let Some(_p) = stream.next().await {}
         });
@@ -630,7 +630,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx);
+            let mut eventloop = super::create_eventloop(options, requests_rx);
 
             loop {
                 let mut stream = eventloop.stream();
@@ -680,7 +680,7 @@ mod test {
         // start the eventloop
         task::spawn(async move {
             time::delay_for(Duration::from_secs(1)).await;
-            let mut eventloop = super::eventloop(options, requests_rx);
+            let mut eventloop = super::create_eventloop(options, requests_rx);
 
             loop {
                 let mut stream = eventloop.stream();

--- a/rumq-client/src/eventloop.rs
+++ b/rumq-client/src/eventloop.rs
@@ -303,10 +303,12 @@ impl MqttEventLoop {
         let id = self.options.client_id();
         let keep_alive = self.options.keep_alive().as_secs() as u16;
         let clean_session = self.options.clean_session();
+        let last_will = self.options.last_will();
 
         let mut connect = connect(id);
         connect.keep_alive = keep_alive;
         connect.clean_session = clean_session;
+        connect.last_will = last_will;
 
         if let Some((username, password)) = self.options.credentials() {
             connect.set_username(username).set_password(password);

--- a/rumq-client/src/eventloop.rs
+++ b/rumq-client/src/eventloop.rs
@@ -46,6 +46,7 @@ pub enum EventLoopError {
 
 /// See [eventloop](eventloop)
 pub fn create_eventloop(options: MqttOptions, requests: impl Requests + 'static) -> MqttEventLoop {
+    #[allow(deprecated)]
     eventloop(options, requests)
 }
 

--- a/rumq-client/src/lib.rs
+++ b/rumq-client/src/lib.rs
@@ -116,7 +116,7 @@ pub(crate) mod eventloop;
 pub(crate) mod network;
 pub(crate) mod state;
 
-pub use eventloop::eventloop;
+pub use eventloop::{create_eventloop, eventloop};
 pub use eventloop::{EventLoopError, MqttEventLoop};
 pub use state::MqttState;
 

--- a/rumq-client/src/lib.rs
+++ b/rumq-client/src/lib.rs
@@ -302,6 +302,10 @@ impl MqttOptions {
         self
     }
 
+    pub fn last_will(&mut self) -> Option<LastWill> {
+        self.last_will.clone()
+    }
+
     pub fn set_ca(&mut self, ca: Vec<u8>) -> &mut Self {
         self.ca = Some(ca);
         self

--- a/rumq-client/src/lib.rs
+++ b/rumq-client/src/lib.rs
@@ -49,7 +49,7 @@
 //!         while let Some(item) = stream.next().await {
 //!             println!("Received = {:?}", item);
 //!         }
-//!         
+//!
 //!         time::delay_for(Duration::from_secs(1)).await;
 //!     }
 //! }
@@ -97,7 +97,7 @@
 //!                 Notification::Connect => requests_tx.send(subscribe).unwrap(),
 //!             }
 //!         }
-//!         
+//!
 //!         time::delay_for(Duration::from_secs(1)).await;
 //!     }
 //! }
@@ -147,9 +147,8 @@ pub enum Notification {
     NetworkClosed,
 }
 
-#[doc(hidden)]
 /// Requests by the client to mqtt event loop. Request are
-/// handle one by one#[derive(Debug)]
+/// handle one by one
 #[derive(Debug)]
 pub enum Request {
     Publish(Publish),
@@ -263,6 +262,8 @@ pub struct MqttOptions {
     throttle: Duration,
     /// maximum number of outgoing inflight messages
     inflight: usize,
+    /// Last will that will be issued on unexpected disconnect
+    last_will: Option<LastWill>,
 }
 
 impl MqttOptions {
@@ -288,12 +289,18 @@ impl MqttOptions {
             notification_channel_capacity: 10,
             throttle: Duration::from_micros(0),
             inflight: 100,
+            last_will: None,
         }
     }
 
     /// Broker address
     pub fn broker_address(&self) -> (String, u16) {
         (self.broker_addr.clone(), self.port)
+    }
+
+    pub fn set_last_will(&mut self, will: LastWill) -> &mut Self {
+        self.last_will = Some(will);
+        self
     }
 
     pub fn set_ca(&mut self, ca: Vec<u8>) -> &mut Self {

--- a/rumq-client/src/lib.rs
+++ b/rumq-client/src/lib.rs
@@ -207,7 +207,6 @@ impl From<Vec<u8>> for Request {
     }
 }
 
-#[doc(hidden)]
 /// Commands sent by the client to mqtt event loop. Commands
 /// are of higher priority and will be `select`ed along with
 /// [request]s

--- a/rumq-core/src/mqtt4/packets.rs
+++ b/rumq-core/src/mqtt4/packets.rs
@@ -125,6 +125,7 @@ pub struct Publish {
 }
 
 /// Creates a new publish packet
+//TODO: maybe this should become private, or just removed and inserted into Publish::new()
 pub fn publish<S: Into<String>, P: Into<Vec<u8>>>(topic: S, qos: QoS, payload: P) -> Publish {
     Publish {
         dup: false,
@@ -137,9 +138,17 @@ pub fn publish<S: Into<String>, P: Into<Vec<u8>>>(topic: S, qos: QoS, payload: P
 }
 
 impl Publish {
+    pub fn new<S: Into<String>, P: Into<Vec<u8>>>(topic: S, qos: QoS, payload: P) -> Self {
+        publish(topic, qos, payload)
+    }
+
     /// Sets packet identifier
     pub fn set_pkid<P: Into<PacketIdentifier>>(&mut self, pkid: P) -> &mut Self {
         self.pkid = Some(pkid.into());
+        self
+    }
+    pub fn set_retain(&mut self, retain: bool) -> &mut Self {
+        self.retain = retain;
         self
     }
 }
@@ -151,6 +160,7 @@ pub struct Subscribe {
     pub topics: Vec<SubscribeTopic>,
 }
 
+//TODO: maybe this should become private, or just removed and inserted into Subscribe::new()
 /// Creates a new subscription packet
 pub fn subscribe<S: Into<String>>(topic: S, qos: QoS) -> Subscribe {
     let topic = SubscribeTopic {
@@ -173,6 +183,9 @@ pub fn empty_subscribe() -> Subscribe {
 }
 
 impl Subscribe {
+    pub fn new<S: Into<String>>(topic: S, qos: QoS) -> Self {
+        subscribe(topic, qos)
+    }
     pub fn add(&mut self, topic: String, qos: QoS) -> &mut Self {
         let topic = SubscribeTopic { topic_path: topic, qos };
         self.topics.push(topic);


### PR DESCRIPTION
In short: 
 - Added so that last_will works
 - Removed a lot of trailing spaces / tabs
 - Added `new()` methods to Publish and Subscribe
 - Added a more descriptive `create_eventloop` that is just using `eventloop()` internally
 - Added deprecated flag to eventloop so that it can be renamed in the future without much hassle