### PR TITLE
Impl std::error::Error for a bunch of error enums

### DIFF
--- a/rumq-broker/Cargo.toml
+++ b/rumq-broker/Cargo.toml
@@ -15,9 +15,9 @@ tokio-util = { version = "0.3", features = ["codec"] }
 futures-util = { version = "0.3", features = ["sink"] }
 tokio-rustls = "0.13"
 rumq-core = { path = "../rumq-core", version = "0.1.0-alpha.8" }
-derive_more = { version = "0.99", default-features = false, features = ["from"] }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 bytes = "0.5"
+thiserror = "1.0.15"
 
 [dev-dependencies]

--- a/rumq-broker/src/connection.rs
+++ b/rumq-broker/src/connection.rs
@@ -1,4 +1,3 @@
-use derive_more::From;
 use rumq_core::mqtt4::{Connack, Packet, Connect, ConnectReturnCode};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::mpsc::error::SendError;
@@ -19,18 +18,27 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::io;
 
-#[derive(Debug, From)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    Io(io::Error),
-    Core(rumq_core::Error),
-    Timeout(Elapsed),
+    #[error("Io")]
+    Io(#[from] io::Error),
+    #[error("rumq core error")]
+    Core(#[from] rumq_core::Error),
+    #[error("Timeout")]
+    Timeout(#[from] Elapsed),
+    #[error("Keep alive")]
     KeepAlive,
-    Send(SendError<(String, RouterMessage)>),
+    #[error("Failed to send router message")]
+    Send(#[from] SendError<(String, RouterMessage)>),
     /// Received a wrong packet while waiting for another packet
+    #[error("Wrong packet received while waiting for another packet")]
     WrongPacket,
     /// Invalid client ID
+    #[error("Invalid client id")]
     InvalidClientId,
+    #[error("Not connack")]
     NotConnack,
+    #[error("Stream don")]
     StreamDone
 }
 

--- a/rumq-broker/src/lib.rs
+++ b/rumq-broker/src/lib.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate log;
 
-use derive_more::From;
 use futures_util::future::join_all;
 use tokio_util::codec::Framed;
 use tokio::net::TcpListener;
@@ -32,18 +31,29 @@ mod router;
 pub use rumq_core as core;
 pub use router::{RouterMessage, Connection};
 
-#[derive(From, Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    Io(io::Error),
-    Mqtt(rumq_core::Error),
-    Timeout(Elapsed),
-    State(state::Error),
-    Tls(TLSError),
+    #[error("I/O")]
+    Io(#[from] io::Error),
+    #[error("MQTT protocol error")]
+    Mqtt(#[from] rumq_core::Error),
+    #[error("Timeout")]
+    Timeout(#[from] Elapsed),
+    #[error("Broker State")]
+    State(#[from] state::Error),
+    #[error("TLS")]
+    Tls(#[from] TLSError),
+    #[error("No server cert")]
     NoServerCert,
+    #[error("No server private key")]
     NoServerPrivateKey,
+    #[error("No ca file")]
     NoCAFile,
+    #[error("No server cert file")]
     NoServerCertFile,
+    #[error("No server key file")]
     NoServerKeyFile,
+    #[error("Disconnected")]
     Disconnected,
 }
 

--- a/rumq-broker/src/router.rs
+++ b/rumq-broker/src/router.rs
@@ -1,4 +1,3 @@
-use derive_more::From;
 use rumq_core::mqtt4::{has_wildcards, matches, QoS, Packet, Connect, Publish, Subscribe, Unsubscribe};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::mpsc::error::TrySendError;
@@ -12,11 +11,14 @@ use std::fmt;
 
 use crate::state::{self, MqttState};
 
-#[derive(Debug, From)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    State(state::Error),
+    #[error("State")]
+    State(#[from] state::Error),
+    #[error("All senders down")]
     AllSendersDown,
-    Mpsc(TrySendError<RouterMessage>),
+    #[error("Error sending message on internal bus")]
+    Mpsc(#[from] TrySendError<RouterMessage>),
 }
 
 /// Router message to orchestrate data between connections. We can also

--- a/rumq-broker/src/state.rs
+++ b/rumq-broker/src/state.rs
@@ -6,27 +6,37 @@ use rumq_core::mqtt4::{
     Subscribe, SubscribeReturnCodes, Suback, Unsubscribe,
 };
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Broker's error reply to client's connect packet
+    #[error("Connect return code: `{0:?}`")]
     Connect(ConnectReturnCode),
     /// Invalid state for a given operation
+    #[error("Invalid state")]
     InvalidState,
     /// Invalid topic
+    #[error("Invalid topic")]
     InvalidTopic,
     /// Received a packet (ack) which isn't asked for
+    #[error("Received a packet (ack) which isn't asked for")]
     Unsolicited(Packet),
     /// Last pingreq isn't acked
+    #[error("Await ping resp")]
     AwaitPingResp,
     /// Received a wrong packet while waiting for another packet
+    #[error("Wrong packet received while waiting for another packet")]
     WrongPacket,
     /// Unsupported packet
+    #[error("Unsupported packet `{0:?}`")]
     UnsupportedPacket(Packet),
     /// Unsupported qos
+    #[error("Unsupported QoS")]
     UnsupportedQoS,
     /// Invalid client ID
+    #[error("Invalid client ID")]
     InvalidClientId,
     /// Disconnect received
+    #[error("Disconnect received: {0}")]
     Disconnect(String),
 }
 

--- a/rumq-client/Cargo.toml
+++ b/rumq-client/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-derive_more = { version = "0.99", default-features = false, features = ["from"] }
 tokio = { version = "0.2", features = ["io-util", "tcp", "dns", "stream", "sync", "time", "macros"] }
 tokio-util = { version = "0.3", features = ["codec"] }
 futures-util = { version =  "0.3", features = ["sink"] }
@@ -19,6 +18,7 @@ webpki = "0.21"
 tokio-rustls = "0.13"
 rumq-core = { path = "../rumq-core", version = "0.1.0-alpha.8" }
 log = "0.4"
+thiserror = "1.0.15"
 
 [dev-dependencies]
 pretty_env_logger = "0.4"

--- a/rumq-client/src/eventloop.rs
+++ b/rumq-client/src/eventloop.rs
@@ -3,7 +3,6 @@ use crate::MqttOptions;
 use crate::{network, Notification, Request};
 
 use async_stream::stream;
-use derive_more::From;
 use futures_util::sink::{Sink, SinkExt};
 use futures_util::stream::{Stream, StreamExt};
 use rumq_core::mqtt4::codec::MqttCodec;
@@ -33,14 +32,21 @@ pub struct MqttEventLoop {
 }
 
 /// Critical errors during eventloop polling
-#[derive(From, Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum EventLoopError {
-    MqttState(StateError),
-    Timeout(Elapsed),
-    Rumq(rumq_core::Error),
-    Network(network::Error),
-    Io(io::Error),
+    #[error("Mqtt state")]
+    MqttState(#[from] StateError),
+    #[error("Timeout")]
+    Timeout(#[from] Elapsed),
+    #[error("Rumq")]
+    Rumq(#[from] rumq_core::Error),
+    #[error("Network")]
+    Network(#[from] network::Error),
+    #[error("I/O")]
+    Io(#[from] io::Error),
+    #[error("Stream done")]
     StreamDone,
+    #[error("Requests done")]
     RequestsDone,
 }
 

--- a/rumq-client/src/state.rs
+++ b/rumq-client/src/state.rs
@@ -12,17 +12,22 @@ pub enum MqttConnectionStatus {
     Disconnected,
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum StateError {
     /// Broker's error reply to client's connect packet
+    #[error("Connect return code `{0:?}`")]
     Connect(ConnectReturnCode),
     /// Invalid state for a given operation
+    #[error("Invalid state for a given operation")]
     InvalidState,
     /// Received a packet (ack) which isn't asked for
+    #[error("Received a packet (ack) which isn't asked for")]
     Unsolicited,
     /// Last pingreq isn't acked
+    #[error("Last pingreq isn't acked")]
     AwaitPingResp,
     /// Received a wrong packet while waiting for another packet
+    #[error("Received a wrong packet while waiting for another packet")]
     WrongPacket,
 }
 

--- a/rumq-core/Cargo.toml
+++ b/rumq-core/Cargo.toml
@@ -10,11 +10,10 @@ edition = "2018"
 [dependencies]
 bytes = "0.5"
 tokio-util = { version = "0.3", features = ["codec"] }
-derive_more = { version = "0.99", default-features = false, features = ["from"] }
 tokio = { version = "0.2", features = ["io-util"] }
 async-trait = "0.1"
 byteorder = "1"
-
+thiserror = "1.0.15"
 
 [dev-dependencies]
 tokio = {version = "0.2", features = ["full", "macros"]}

--- a/rumq-core/src/lib.rs
+++ b/rumq-core/src/lib.rs
@@ -1,24 +1,33 @@
-use derive_more::From;
 use std::io;
 use std::string::FromUtf8Error;
 
 pub mod mqtt4;
 
 // TODO Probably convert this to io::Error (for simplicity) and provide a function for meaningful enum?
-#[derive(Debug, From)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Invalid connect return code `{0}`")]
     InvalidConnectReturnCode(u8),
+    #[error("Invalid level `{1}` for protocol `{0}`")]
     InvalidProtocolLevel(String, u8),
+    #[error("Incorrect packet format")]
     IncorrectPacketFormat,
+    #[error("Unsupported QoS")]
     UnsupportedQoS,
+    #[error("Unsupported packet type `{0}`")]
     UnsupportedPacketType(u8),
+    #[error("Payload size incorrect")]
     PayloadSizeIncorrect,
+    #[error("Payload too long")]
     PayloadTooLong,
+    #[error("Payload size limit exceeded")]
     PayloadSizeLimitExceeded,
+    #[error("Payload required")]
     PayloadRequired,
-    #[from]
-    TopicNameMustNotContainNonUtf8(FromUtf8Error),
+    #[error("Topic name must only contain valid UTF-8")]
+    TopicNameMustNotContainNonUtf8(#[from] FromUtf8Error),
+    #[error("Malformed remaining length")]
     MalformedRemainingLength,
-    #[from]
-    Io(io::Error),
+    #[error("Io")]
+    Io(#[from] io::Error),
 }

--- a/rumq-core/src/mqtt4/packets.rs
+++ b/rumq-core/src/mqtt4/packets.rs
@@ -1,11 +1,15 @@
-use derive_more::From;
-
 use crate::mqtt4::QoS;
 use std::fmt;
 
 /// Packet identifier for packets types that require broker to acknowledge
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, From)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PacketIdentifier(pub u16);
+
+impl From<u16> for PacketIdentifier {
+    fn from(value: u16) -> Self {
+        PacketIdentifier(value)
+    }
+}
 
 /// Mqtt protocol version
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
- Adds dependency on `thiserror`, but also removes `derive-more`
- Adds Error implementation on all enums found with `enum.*Error`
- This also required implementations for Display, which were added in a
  best-effort fashion.

Fixes #61