### PR TITLE
Update doc comment

### DIFF
--- a/rumq-client/src/eventloop.rs
+++ b/rumq-client/src/eventloop.rs
@@ -51,7 +51,7 @@ pub enum EventLoopError {
 }
 
 /// Returns an object which encompasses state of the connection.
-/// Use this to create a `Stream` with `stream()` method and poll it with tokio.
+/// Use this to create a `Stream` with `connect().await?` method and poll it with tokio.
 ///
 /// The choice of separating `MqttEventLoop` and `stream` methods is to get access to the
 /// internal state and mqtt options after the work with the `Stream` is done or stopped.


### PR DESCRIPTION
Not sure how much of `.await` and `?` should be included.
The phrasing "poll it with tokio" sounds very beginnerish, so that might be relevant to include in the same vein.
That has indeed been a change, where it used to neither return a Future not a Result, all errors going inside the Stream.