### PR TITLE
Ecc key

### DIFF
--- a/rumq-client/src/lib.rs
+++ b/rumq-client/src/lib.rs
@@ -257,6 +257,8 @@ pub struct MqttOptions {
     inflight: usize,
     /// Last will that will be issued on unexpected disconnect
     last_will: Option<LastWill>,
+    /// Key type for TLS 
+    key_type: Option<String>,
 }
 
 impl MqttOptions {
@@ -283,6 +285,7 @@ impl MqttOptions {
             throttle: Duration::from_micros(0),
             inflight: 100,
             last_will: None,
+            key_type: None,
         }
     }
 
@@ -433,6 +436,18 @@ impl MqttOptions {
     pub fn inflight(&self) -> usize {
         self.inflight
     }
+
+    /// Set key type
+    pub fn set_key_type(&mut self, key_type: String) -> &mut Self {
+        self.key_type = Some(key_type);
+        self
+    }
+
+    /// get key type
+    pub fn get_key_type(&self) -> Option<String>{
+        self.key_type.clone()
+    }
+
 }
 
 #[cfg(test)]

--- a/rumq-client/src/lib.rs
+++ b/rumq-client/src/lib.rs
@@ -439,7 +439,11 @@ impl MqttOptions {
 
     /// Set key type
     pub fn set_key_type(&mut self, key_type: String) -> &mut Self {
-        self.key_type = Some(key_type);
+        match key_type.as_str() {
+            "RSA" => self.key_type = Some(key_type),
+            "ECC" => self.key_type = Some(key_type),
+            _ => panic!("Key type should be either ECC or RSA"),
+        };
         self
     }
 

--- a/rumq-client/src/lib.rs
+++ b/rumq-client/src/lib.rs
@@ -469,4 +469,10 @@ mod test {
     fn no_client_id() {
         let _mqtt_opts = MqttOptions::new("", "127.0.0.1", 1883).set_clean_session(true);
     }
+
+    #[test]
+    #[should_panic]
+    fn set_key_type_illegal_panics() {
+        let _mqtt_opts = MqttOptions::new("test_ops", "localhost", 8883).set_key_type("ABC".to_string());
+    }
 }

--- a/rumq-client/src/lib.rs
+++ b/rumq-client/src/lib.rs
@@ -443,12 +443,8 @@ impl MqttOptions {
         self.inflight
     }
 
-    /// Use this setter to modify key_type enum
+    /// Use this setter to modify key_type enum, by default RSA
     pub fn set_key_type(&mut self, key_type: Key) -> &mut Self {
-        // match key_type {
-        //     Key::RSA => self.key_type = Some("RSA".to_owned()),
-        //     Key::ECC => self.key_type = Some("ECC".to_owned()),
-        // };
         self.key_type = key_type;
         self
     }

--- a/rumq-client/src/lib.rs
+++ b/rumq-client/src/lib.rs
@@ -152,7 +152,7 @@ pub enum Request {
     Disconnect,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum Key{
     RSA,
     ECC,
@@ -264,7 +264,7 @@ pub struct MqttOptions {
     /// Last will that will be issued on unexpected disconnect
     last_will: Option<LastWill>,
     /// Key type for TLS 
-    key_type: Option<String>,
+    key_type: Key,
 }
 
 impl MqttOptions {
@@ -291,7 +291,7 @@ impl MqttOptions {
             throttle: Duration::from_micros(0),
             inflight: 100,
             last_will: None,
-            key_type: None,
+            key_type: Key::RSA,
         }
     }
 
@@ -443,18 +443,19 @@ impl MqttOptions {
         self.inflight
     }
 
-    /// Set key type
+    /// Use this setter to modify key_type enum
     pub fn set_key_type(&mut self, key_type: Key) -> &mut Self {
-        match key_type {
-            Key::RSA => self.key_type = Some("RSA".to_owned()),
-            Key::ECC => self.key_type = Some("ECC".to_owned()),
-        };
+        // match key_type {
+        //     Key::RSA => self.key_type = Some("RSA".to_owned()),
+        //     Key::ECC => self.key_type = Some("ECC".to_owned()),
+        // };
+        self.key_type = key_type;
         self
     }
 
     /// get key type
-    pub fn get_key_type(&self) -> Option<String>{
-        self.key_type.clone()
+    pub fn get_key_type(&self) -> Key{
+        self.key_type
     }
 
 }

--- a/rumq-client/src/lib.rs
+++ b/rumq-client/src/lib.rs
@@ -438,7 +438,8 @@ impl MqttOptions {
     }
 
     /// Set key type
-    pub fn set_key_type(&mut self, key_type: String) -> &mut Self {
+    pub fn set_key_type<S: Into<String>>(&mut self, key_type: S) -> &mut Self {
+        let key_type = key_type.into();
         match key_type.as_str() {
             "RSA" => self.key_type = Some(key_type),
             "ECC" => self.key_type = Some(key_type),
@@ -473,6 +474,6 @@ mod test {
     #[test]
     #[should_panic]
     fn set_key_type_illegal_panics() {
-        let _mqtt_opts = MqttOptions::new("test_ops", "localhost", 8883).set_key_type("ABC".to_string());
+        let _mqtt_opts = MqttOptions::new("test_ops", "localhost", 8883).set_key_type("ABC");
     }
 }

--- a/rumq-client/src/lib.rs
+++ b/rumq-client/src/lib.rs
@@ -152,6 +152,12 @@ pub enum Request {
     Disconnect,
 }
 
+#[derive(Debug)]
+pub enum Key{
+    RSA,
+    ECC,
+}
+
 impl From<Publish> for Request {
     fn from(publish: Publish) -> Request {
         return Request::Publish(publish);
@@ -438,12 +444,10 @@ impl MqttOptions {
     }
 
     /// Set key type
-    pub fn set_key_type<S: Into<String>>(&mut self, key_type: S) -> &mut Self {
-        let key_type = key_type.into();
-        match key_type.as_str() {
-            "RSA" => self.key_type = Some(key_type),
-            "ECC" => self.key_type = Some(key_type),
-            _ => panic!("Key type should be either ECC or RSA"),
+    pub fn set_key_type(&mut self, key_type: Key) -> &mut Self {
+        match key_type {
+            Key::RSA => self.key_type = Some("RSA".to_owned()),
+            Key::ECC => self.key_type = Some("ECC".to_owned()),
         };
         self
     }
@@ -469,11 +473,5 @@ mod test {
     #[should_panic]
     fn no_client_id() {
         let _mqtt_opts = MqttOptions::new("", "127.0.0.1", 1883).set_clean_session(true);
-    }
-
-    #[test]
-    #[should_panic]
-    fn set_key_type_illegal_panics() {
-        let _mqtt_opts = MqttOptions::new("test_ops", "localhost", 8883).set_key_type("ABC");
     }
 }

--- a/rumq-client/src/network.rs
+++ b/rumq-client/src/network.rs
@@ -25,6 +25,8 @@ pub enum Error {
     TLS(#[from] TLSError),
     #[error("No valid cert in chain")]
     NoValidCertInChain,
+    #[error("Invalid key type")]
+    InvalidKeyType,
 }
 
 // The cert handling functions return unit right now, this is a shortcut
@@ -52,6 +54,8 @@ pub async fn tls_connect(options: &MqttOptions) -> Result<TlsStream<TcpStream>, 
     // Add der encoded client cert and key
     if let Some(client) = options.client_auth.as_ref() {
         let certs = certs(&mut BufReader::new(Cursor::new(client.0.clone())))?;
+        // TODO: READ ECC KEY TYPE AS WELL
+       
         let mut keys = rsa_private_keys(&mut BufReader::new(Cursor::new(client.1.clone())))?;
         config.set_single_client_cert(certs, keys.remove(0))?;
     }

--- a/rumq-client/src/network.rs
+++ b/rumq-client/src/network.rs
@@ -63,7 +63,7 @@ pub async fn tls_connect(options: &MqttOptions) -> Result<TlsStream<TcpStream>, 
                     _ => return Err(Error::InvalidKeyType),
                 }
             },
-            // Assume RSA key type by default.
+            // Assume RSA key type by default?
             None => rsa_private_keys(&mut BufReader::new(Cursor::new(client.1.clone()))),
         };
         let mut keys = match read_keys {

--- a/rumq-client/src/network.rs
+++ b/rumq-client/src/network.rs
@@ -25,8 +25,6 @@ pub enum Error {
     TLS(#[from] TLSError),
     #[error("No valid cert in chain")]
     NoValidCertInChain,
-    #[error("Invalid key type")]
-    InvalidKeyType,
 }
 
 // The cert handling functions return unit right now, this is a shortcut


### PR DESCRIPTION
Changes summary:

- Added `key_type` attribute to MqttOptions of Type `Option<String>`
- Panics if `key_type` supplied by user is illegal.
- Call appropriate key reading api depending upon type of key.
- By default assume `RSA`.